### PR TITLE
Add support for AwsS3V3

### DIFF
--- a/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
+++ b/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+use Oneup\FlysystemBundle\DependencyInjection\Factory\AdapterFactoryInterface;
+
+class AwsS3V2Factory implements AdapterFactoryInterface
+{
+    public function getKey()
+    {
+        return 'awss3v2';
+    }
+
+    public function create(ContainerBuilder $container, $id, array $config)
+    {
+        $definition = $container
+            ->setDefinition($id, new DefinitionDecorator('oneup_flysystem.adapter.awss3v2'))
+            ->replaceArgument(0, new Reference($config['client']))
+            ->replaceArgument(1, $config['bucket'])
+            ->replaceArgument(2, $config['prefix'])
+        ;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('client')->isRequired()->end()
+                ->scalarNode('bucket')->isRequired()->end()
+                ->scalarNode('prefix')->defaultNull()->end()
+            ->end()
+        ;
+    }
+}

--- a/DependencyInjection/Factory/Adapter/AwsS3V3Factory.php
+++ b/DependencyInjection/Factory/Adapter/AwsS3V3Factory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+use Oneup\FlysystemBundle\DependencyInjection\Factory\AdapterFactoryInterface;
+
+class AwsS3V3Factory implements AdapterFactoryInterface
+{
+    public function getKey()
+    {
+        return 'awss3v3';
+    }
+
+    public function create(ContainerBuilder $container, $id, array $config)
+    {
+        $definition = $container
+            ->setDefinition($id, new DefinitionDecorator('oneup_flysystem.adapter.awss3v3'))
+            ->replaceArgument(0, new Reference($config['client']))
+            ->replaceArgument(1, $config['bucket'])
+            ->replaceArgument(2, $config['prefix'])
+        ;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('client')->isRequired()->end()
+                ->scalarNode('bucket')->isRequired()->end()
+                ->scalarNode('prefix')->defaultNull()->end()
+            ->end()
+        ;
+    }
+}

--- a/Resources/config/factories.xml
+++ b/Resources/config/factories.xml
@@ -14,10 +14,10 @@
                <service id="oneup_flysystem.adapter_factory.zip" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\ZipFactory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>
-               <service id="oneup_flysystem.adapter_factory.awss3v2" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AwsS3Factory">
+               <service id="oneup_flysystem.adapter_factory.awss3v2" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AwsS3V2Factory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>
-               <service id="oneup_flysystem.adapter_factory.awss3v3" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AwsS3Factory">
+               <service id="oneup_flysystem.adapter_factory.awss3v3" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AwsS3V3Factory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>
                <service id="oneup_flysystem.adapter_factory.dropbox" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\DropboxFactory">

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,10 @@
 
     "require": {
         "symfony/framework-bundle": ">=2.0",
-        "league/flysystem": "~1.0",
+        "league/flysystem": "~1.0"
+    },
+
+    "require-dev": {
         "league/flysystem-rackspace": "1.0.0",
         "league/flysystem-webdav": "1.0.0",
         "league/flysystem-aws-s3-v2": "1.0.0",
@@ -24,10 +27,7 @@
         "league/flysystem-dropbox": "1.0.0",
         "league/flysystem-cached-adapter": "1.0.0",
         "league/flysystem-sftp": "1.0.0",
-        "league/flysystem-ziparchive": "1.0.0"
-    },
-
-    "require-dev": {
+        "league/flysystem-ziparchive": "1.0.0",
         "phpunit/phpunit": "4.4.*",
         "symfony/finder": ">=2.0",
         "symfony/browser-kit": ">=2.0"


### PR DESCRIPTION
Split the current AwsS3 Adapter into 2 files for V2 and V3
(following the same pattern that flysystem is using)
This allows us to support multiple versions of these adapters
without messy code.