### PR TITLE
Invalid key causing 'Unrecognized option "awss3" under... " error

### DIFF
--- a/Resources/doc/adapter_awss3.md
+++ b/Resources/doc/adapter_awss3.md
@@ -22,7 +22,7 @@ Set this service as the value of the `client` key in the `oneup_flysystem` confi
 oneup_flysystem:
     adapters:
         acme.flysystem_adapter:
-            awss3:
+            awss3v2:
                 client: acme.s3_client
                 bucket: ~
                 prefix: ~


### PR DESCRIPTION
Documentation doesn't match code. There should be 'awss3v2' or 'awss3v3' key instead of 'awss3'