### PR TITLE
add AWS-S3-V2 options

### DIFF
--- a/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
+++ b/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
@@ -30,10 +30,10 @@ class AwsS3V2Factory implements AdapterFactoryInterface
     {
         $node
             ->children()
-            ->scalarNode('client')->isRequired()->end()
-            ->scalarNode('bucket')->isRequired()->end()
-            ->scalarNode('prefix')->defaultNull()->end()
-            ->arrayNode('options')->prototype('scalar')->end()
+                ->scalarNode('client')->isRequired()->end()
+                ->scalarNode('bucket')->isRequired()->end()
+                ->scalarNode('prefix')->defaultNull()->end()
+                ->arrayNode('options')->prototype('scalar')->end()
             ->end()
         ;
     }

--- a/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
+++ b/DependencyInjection/Factory/Adapter/AwsS3V2Factory.php
@@ -22,6 +22,7 @@ class AwsS3V2Factory implements AdapterFactoryInterface
             ->replaceArgument(0, new Reference($config['client']))
             ->replaceArgument(1, $config['bucket'])
             ->replaceArgument(2, $config['prefix'])
+            ->addArgument((array)$config['options'])
         ;
     }
 
@@ -29,9 +30,10 @@ class AwsS3V2Factory implements AdapterFactoryInterface
     {
         $node
             ->children()
-                ->scalarNode('client')->isRequired()->end()
-                ->scalarNode('bucket')->isRequired()->end()
-                ->scalarNode('prefix')->defaultNull()->end()
+            ->scalarNode('client')->isRequired()->end()
+            ->scalarNode('bucket')->isRequired()->end()
+            ->scalarNode('prefix')->defaultNull()->end()
+            ->arrayNode('options')->prototype('scalar')->end()
             ->end()
         ;
     }


### PR DESCRIPTION
im missing the options to set ACL propertys by default

```
oneup_flysystem:
    adapters:
        foo_adapter:
            awss3v2:
                client: AmazonWebServices.S3
                bucket: 'bar'
                prefix: ~
                options:
                    acl: 'public-read'
```