### PR TITLE
Fixed typo in cached adapter service name

### DIFF
--- a/DependencyInjection/OneupFlysystemExtension.php
+++ b/DependencyInjection/OneupFlysystemExtension.php
@@ -86,7 +86,7 @@ class OneupFlysystemExtension extends Extension
             $cache = $caches[$config['cache']];
 
             $container
-                ->setDefinition($adapter . '_cached', new DefinitionDecorator('oneup_flystem_adapter.cached'))
+                ->setDefinition($adapter . '_cached', new DefinitionDecorator('oneup_flysystem.adapter.cached'))
                 ->replaceArgument(0, new Reference($adapter))
                 ->replaceArgument(1, new Reference($cache));
         }

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -7,7 +7,7 @@
                <service id="oneup_flysystem.adapter.local" class="League\Flysystem\Adapter\Local" abstract="true" public="false">
                    <argument /><!-- Directory -->
                </service>
-               <service id="oneup_flystem_adapter.cached" class="League\Flysystem\Cached\CachedAdapter" abstract="true" public="false">
+               <service id="oneup_flysystem.adapter.cached" class="League\Flysystem\Cached\CachedAdapter" abstract="true" public="false">
                    <argument /><!-- Adapter -->
                    <argument /><!-- CacheAdapter -->
                </service>


### PR DESCRIPTION
`flystem` should be `flysystem` :) 

However I'm not sure if this is a BC break for somebody. I guess it shouldn't be as it is used as a definition decorator.