### PR TITLE
Added support for extra constructor arguments for the Local adapter.

### DIFF
--- a/DependencyInjection/Factory/Adapter/LocalFactory.php
+++ b/DependencyInjection/Factory/Adapter/LocalFactory.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Oneup\FlysystemBundle\DependencyInjection\Factory\AdapterFactoryInterface;
+use League\Flysystem\Adapter\Local;
 
 class LocalFactory implements AdapterFactoryInterface
 {
@@ -19,6 +20,8 @@ class LocalFactory implements AdapterFactoryInterface
         $container
             ->setDefinition($id, new DefinitionDecorator('oneup_flysystem.adapter.local'))
             ->replaceArgument(0, $config['directory'])
+            ->replaceArgument(1, $config['writeFlags'])
+            ->replaceArgument(2, $config['linkHandling'])
         ;
     }
 
@@ -27,6 +30,8 @@ class LocalFactory implements AdapterFactoryInterface
         $node
             ->children()
                 ->scalarNode('directory')->isRequired()->end()
+                ->scalarNode('writeFlags')->defaultValue(LOCK_EX)->end()
+                ->scalarNode('linkHandling')->defaultValue(Local::DISALLOW_LINKS)->end()
             ->end()
         ;
     }

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -6,6 +6,8 @@
            <services>
                <service id="oneup_flysystem.adapter.local" class="League\Flysystem\Adapter\Local" abstract="true" public="false">
                    <argument /><!-- Directory -->
+                   <argument /><!-- WriteFlags -->
+                   <argument /><!-- LinkHandling -->
                </service>
                <service id="oneup_flysystem.adapter.cached" class="League\Flysystem\Cached\CachedAdapter" abstract="true" public="false">
                    <argument /><!-- Adapter -->

--- a/Resources/doc/adapter_local.md
+++ b/Resources/doc/adapter_local.md
@@ -10,7 +10,11 @@ oneup_flysystem:
         my_adapter:
             local:
                 directory: %kernel.root_dir%/../uploads
+                writeFlags: ~
+                linkHandling: ~
 ```
+
+For more details on the other parameters, take a look at the [Flysystem documentation](http://flysystem.thephpleague.com/adapter/local/).
 
 ## More to know
 * [Create and use your filesystem](filesystem_create.md)


### PR DESCRIPTION
Added support for the extra constructor arguments (writeFlags and linkHandling) that were added to the flysystem. 

See:
http://flysystem.thephpleague.com/adapter/local/
https://github.com/thephpleague/flysystem/blob/master/src/Adapter/Local.php#L63