### PR TITLE
Support any custom flysystem adapter

### DIFF
--- a/DependencyInjection/Factory/Adapter/CustomAdapterFactory.php
+++ b/DependencyInjection/Factory/Adapter/CustomAdapterFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter;
+
+use Oneup\FlysystemBundle\DependencyInjection\Factory\AdapterFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+class CustomAdapterFactory implements AdapterFactoryInterface
+{
+    public function getKey()
+    {
+        return 'custom';
+    }
+
+    public function create(ContainerBuilder $container, $id, array $config)
+    {
+        $container->setAlias($id, $config['service']);
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+            ->variableNode('service')->isRequired()->cannotBeEmpty()->end()
+            ->end()
+        ;
+    }
+}

--- a/Resources/config/factories.xml
+++ b/Resources/config/factories.xml
@@ -41,6 +41,9 @@
                <service id="oneup_flysystem.adapter_factory.gridfs" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\GridFSFactory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>
+               <service id="oneup_flysystem.adapter_factory.customadapter" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\CustomAdapterFactory">
+                   <tag name="oneup_flysystem.adapter_factory" />
+               </service>
 
                <!-- Cache factories -->
                <service id="oneup_flysystem.cache_factory.adapter" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Cache\AdapterFactory">

--- a/Resources/doc/adapter_awss3.md
+++ b/Resources/doc/adapter_awss3.md
@@ -46,7 +46,7 @@ oneup_flysystem:
                 prefix: ~
 ```
 
-For more details on the other paramters, take a look at the [Flysystem documentation](https://github.com/thephpleague/flysystem#aws-s3-setup).
+For more details on the other parameters, take a look at the [Flysystem documentation](https://github.com/thephpleague/flysystem#aws-s3-setup).
 
 ## More to know
 * [Create and use your filesystem](filesystem_create.md)

--- a/Resources/doc/adapter_custom.md
+++ b/Resources/doc/adapter_custom.md
@@ -1,0 +1,18 @@
+# Use the Custom adapter
+
+In order to use a custom adapter, you first need to create
+a service implementing the `League\Flysystem\AdapterInterface`.
+
+Set this service as the value of the `service` key in the `oneup_flysystem` configuration.
+
+```yml
+oneup_flysystem:
+    adapters:
+        acme.flysystem_adapter:
+            custom:
+                service: my_flysystem_service
+```
+
+## More to know
+* [Create and use your filesystem](filesystem_create.md)
+* [Add a cache](filesystem_cache.md)

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -88,6 +88,7 @@ There are a bunch of adapters for you to use:
 * [ZipArchive](adapter_ziparchive.md)
 * [GridFS](adapter_gridfs.md)
 * [Copy.com](https://github.com/copy-app/php-client-library)
+* [Custom](adapter_custom.md)
 
 ### Step 4: Next steps
 
@@ -97,3 +98,4 @@ After installing and setting up the basic functionality of this bundle you can m
 * [Cache your filesystems](filesystem_cache.md)
 * [Plugin filesystems](filesystem_plugin.md)
 * [Running the tests](tests.md)
+* [Use your own flysystem adapters](adapter_custom.md)


### PR DESCRIPTION
This PR enables OneupFlysystemBundle to work with any `League\Flysystem\AdapterInterface` registered into the system without the need of modifying the basecode.