### PR TITLE
Added support for permissions constructor argument for the Local adapter

### DIFF
--- a/DependencyInjection/Factory/Adapter/LocalFactory.php
+++ b/DependencyInjection/Factory/Adapter/LocalFactory.php
@@ -22,6 +22,7 @@ class LocalFactory implements AdapterFactoryInterface
             ->replaceArgument(0, $config['directory'])
             ->replaceArgument(1, $config['writeFlags'])
             ->replaceArgument(2, $config['linkHandling'])
+            ->replaceArgument(3, $config['permissions'])
         ;
     }
 
@@ -32,6 +33,10 @@ class LocalFactory implements AdapterFactoryInterface
                 ->scalarNode('directory')->isRequired()->end()
                 ->scalarNode('writeFlags')->defaultValue(LOCK_EX)->end()
                 ->scalarNode('linkHandling')->defaultValue(Local::DISALLOW_LINKS)->end()
+                ->variableNode('permissions')
+                    ->defaultValue([])
+                    ->treatNullLike([])
+                ->end()
             ->end()
         ;
     }

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -8,6 +8,7 @@
                    <argument /><!-- Directory -->
                    <argument /><!-- WriteFlags -->
                    <argument /><!-- LinkHandling -->
+                   <argument /><!-- Permissions -->
                </service>
                <service id="oneup_flysystem.adapter.cached" class="League\Flysystem\Cached\CachedAdapter" abstract="true" public="false">
                    <argument /><!-- Adapter -->

--- a/Resources/doc/adapter_local.md
+++ b/Resources/doc/adapter_local.md
@@ -12,6 +12,7 @@ oneup_flysystem:
                 directory: %kernel.root_dir%/../uploads
                 writeFlags: ~
                 linkHandling: ~
+                permissions: ~
 ```
 
 For more details on the other parameters, take a look at the [Flysystem documentation](http://flysystem.thephpleague.com/adapter/local/).


### PR DESCRIPTION
Added support for permissions constructor argument for the Local adapter that were added to the flysystem (in 1.0.14).

See:
http://flysystem.thephpleague.com/adapter/local/
https://github.com/thephpleague/flysystem/blob/master/src/Adapter/Local.php#L69