### PR TITLE
Change S3Client service definition for AwsS3v3

### DIFF
--- a/Resources/doc/adapter_awss3.md
+++ b/Resources/doc/adapter_awss3.md
@@ -13,8 +13,6 @@ This version requires you to use the "v4" of the signature.
 services:
     acme.s3_client:
         class: Aws\S3\S3Client
-        factory_class: Aws\S3\S3Client
-        factory_method: factory
         arguments:
             -
                 version: '2006-03-01' # or 'latest'


### PR DESCRIPTION
Using the factory method is deprecated

See https://docs.aws.amazon.com/aws-sdk-php/v3/guide/guide/migration.html#client-instantiation-uses-the-constructor