### PR TITLE
Fix Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,14 @@
 
     "require": {
         "php": ">=5.4.0",
-        "symfony/framework-bundle": ">=2.0|~3.0",
+        "symfony/framework-bundle": "~2.0|~3.0",
         "league/flysystem": "~1.0"
     },
 
     "require-dev": {
         "phpunit/phpunit": "4.4.*",
-        "symfony/finder": ">=2.0|~3.0",
-        "symfony/browser-kit": ">=2.0|~3.0",
+        "symfony/finder": "~2.0|~3.0",
+        "symfony/browser-kit": "~2.0|~3.0",
         "league/flysystem-aws-s3-v2": "~1.0",
         "league/flysystem-cached-adapter": "~1.0",
         "league/flysystem-copy": "~1.0",


### PR DESCRIPTION
``>=2.0`` should not be used because it allows Symfony 4.x and newer. We only want to allow Symfony 2.x and Symfony 3.x yet.