### PR TITLE
Implement getConfiguration() in OneupFlysystemExtension

### DIFF
--- a/DependencyInjection/OneupFlysystemExtension.php
+++ b/DependencyInjection/OneupFlysystemExtension.php
@@ -44,6 +44,13 @@ class OneupFlysystemExtension extends Extension
         }
     }
 
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        list($adapterFactories, $cacheFactories) = $this->getFactories();
+
+        return new Configuration($adapterFactories, $cacheFactories);
+    }
+
     private function createCache($name, array $config, ContainerBuilder $container, array $factories)
     {
         foreach ($config as $key => $adapter) {

--- a/Tests/DependencyInjection/OneupFlysystemExtensionTest.php
+++ b/Tests/DependencyInjection/OneupFlysystemExtensionTest.php
@@ -6,6 +6,8 @@ use League\Flysystem\AdapterInterface;
 use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
 use Oneup\FlysystemBundle\Tests\Model\ContainerAwareTestCase;
+use Oneup\FlysystemBundle\DependencyInjection\OneupFlysystemExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class OneupFlysystemExtensionTest extends ContainerAwareTestCase
 {
@@ -94,5 +96,12 @@ class OneupFlysystemExtensionTest extends ContainerAwareTestCase
         $adapter = $filesystem->getAdapter();
 
         $this->assertInstanceOf('League\Flysystem\Cached\CachedAdapter', $adapter);
+    }
+
+    public function testGetConfiguration()
+    {
+        $extension = new OneupFlysystemExtension();
+        $configuration = $extension->getConfiguration([], new ContainerBuilder());
+        $this->assertInstanceOf('Oneup\FlysystemBundle\DependencyInjection\Configuration', $configuration);
     }
 }


### PR DESCRIPTION
This makes the bundle work with the `config:dump-reference` command.

Thanks for the cool bundle!