### PR TITLE
Added flysystem-memory to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "league/flysystem-copy": "~1.0",
         "league/flysystem-dropbox": "~1.0",
         "league/flysystem-gridfs": "~1.0",
+        "league/flysystem-memory": "~1.0",
         "league/flysystem-rackspace": "~1.0",
         "league/flysystem-sftp": "~1.0",
         "league/flysystem-webdav": "~1.0",


### PR DESCRIPTION
I've submitted that PR to check if `features/adapter-memory` is mergeable.
Could you consider merging `features/adapter-memory` and pushing a new release?

I would be glad to help if you need some.