### PR TITLE
Fix FTP_BINARY notice when ftp module not loaded

### DIFF
--- a/DependencyInjection/Factory/Adapter/FtpFactory.php
+++ b/DependencyInjection/Factory/Adapter/FtpFactory.php
@@ -37,7 +37,7 @@ class FtpFactory implements AdapterFactoryInterface
                 ->scalarNode('permPrivate')->defaultValue(0000)->end()
                 ->scalarNode('permPublic')->defaultNull(0744)->end()
                 ->booleanNode('passive')->defaultTrue()->end()
-                ->scalarNode('transferMode')->defaultValue(FTP_BINARY)->end()
+                ->scalarNode('transferMode')->defaultValue(defined('FTP_BINARY') ? FTP_BINARY : null)->end()
                 ->scalarNode('systemType')->defaultNull()->end()
                 ->booleanNode('ignorePassiveAddress')->defaultNull()->end()
                 ->booleanNode('recurseManually')->defaultFalse()->end()

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
 
     "suggest": {
         "ext-fileinfo": "Required for MimeType",
+        "ext-ftp": "Required for FTP and SFTP",
         "league/flysystem-aws-s3-v2": "Use S3 storage with AWS SDK v2",
         "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
         "league/flysystem-copy": "Allows you to use Copy.com storage",


### PR DESCRIPTION
Should I change default FTP_BINARY to FTP_ASCII like in https://github.com/KnpLabs/KnpGaufretteBundle/blob/master/DependencyInjection/Factory/FtpAdapterFactory.php ?