### PR TITLE
Fix configuration validation since symfony 3.2.4: #21057

### DIFF
--- a/DependencyInjection/OneupFlysystemExtension.php
+++ b/DependencyInjection/OneupFlysystemExtension.php
@@ -51,6 +51,9 @@ class OneupFlysystemExtension extends Extension
 
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('factories.xml');
+
         list($adapterFactories, $cacheFactories) = $this->getFactories($container);
 
         return new Configuration($adapterFactories, $cacheFactories);


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/21057

The factories was not loaded on getConfiguration call and this is blocking since last release of Symfony (3.2.4).