### PR TITLE
fixes #163 - BC with SF 4

### DIFF
--- a/DependencyInjection/OneupFlysystemExtension.php
+++ b/DependencyInjection/OneupFlysystemExtension.php
@@ -126,11 +126,12 @@ class OneupFlysystemExtension extends Extension
             ->setDefinition($id, new ChildDefinition('oneup_flysystem.filesystem'))
             ->replaceArgument(0, new Reference($cache ? $adapter.'_cached' : $adapter))
             ->replaceArgument(1, $options)
-            ->addTag('oneup_flysystem.filesystem', $tagParams);
+            ->addTag('oneup_flysystem.filesystem', $tagParams)
+            ->setPublic(true);
 
         if (!empty($config['alias'])) {
             $container->getDefinition($id)->setPublic(false);
-            $container->setAlias($config['alias'], $id);
+            $container->setAlias($config['alias'], $id)->setPublic(true);
         }
 
         // Attach Plugins


### PR DESCRIPTION
The services are set as restricted by default on SF 4, so we can explicitly define them as public.