### PR TITLE
Allow symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
 
 env:
-  - SYMFONY_VERSION=^3.3
+  - SYMFONY_VERSION=^3.4 COMPOSER_FLAGS=--prefer-lowest
   - SYMFONY_VERSION=^4.0
   - SYMFONY_VERSION=^5.0
   - SYMFONY_VERSION=dev-master
@@ -20,21 +19,17 @@ matrix:
   allow_failures:
     - env: SYMFONY_VERSION=dev-master
   exclude:
-    - php: 7.0
-      env: SYMFONY_VERSION=^4.0
-    - php: 7.0
-      env: SYMFONY_VERSION=^5.0   
     - php: 7.1
       env: SYMFONY_VERSION=^5.0       
-    - php: 7.0
+    - php: 7.1
       env: SYMFONY_VERSION=dev-master
 
 before_install:
   - travis_retry composer selfupdate
 
 before_script:
-  - if [ "$SYMFONY_VERSION" = "^4.0" ]; then composer config minimum-stability dev; composer config prefer-stable true; fi
+  - if [ "$SYMFONY_VERSION" = "dev-master" ]; then composer config minimum-stability dev; composer config prefer-stable true; fi
   - travis_wait composer require symfony/framework-bundle:${SYMFONY_VERSION} --prefer-source
-  - travis_wait composer install --dev --prefer-source
+  - travis_wait composer update --dev --prefer-source ${COMPOSER_FLAGS}
 
 script: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
 env:
   - SYMFONY_VERSION=^3.3
   - SYMFONY_VERSION=^4.0
+  - SYMFONY_VERSION=^5.0
   - SYMFONY_VERSION=dev-master
 
 cache:
@@ -21,6 +22,10 @@ matrix:
   exclude:
     - php: 7.0
       env: SYMFONY_VERSION=^4.0
+    - php: 7.0
+      env: SYMFONY_VERSION=^5.0   
+    - php: 7.1
+      env: SYMFONY_VERSION=^5.0       
     - php: 7.0
       env: SYMFONY_VERSION=dev-master
 

--- a/Tests/App/config/config.yml
+++ b/Tests/App/config/config.yml
@@ -2,11 +2,11 @@ framework:
     translator: { fallback: en }
     secret: secret
     router:
-        resource: "%kernel.project_dir/config/routing.yml"
+        resource: "%kernel.project_dir%/config/routing.yml"
         strict_requirements: "%kernel.debug%"
     default_locale: en
     session: ~
-    test: ~
+    test: true
     trusted_hosts: ~
 
 oneup_flysystem:
@@ -17,7 +17,7 @@ oneup_flysystem:
     adapters:
         myadapter:
             local:
-                directory: "kernel.project_dir%/cache"
+                directory: "%kernel.project_dir%/cache"
 
     filesystems:
         myfilesystem:

--- a/Tests/App/config/config.yml
+++ b/Tests/App/config/config.yml
@@ -2,10 +2,8 @@ framework:
     translator: { fallback: en }
     secret: secret
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
-        strict_requirements: %kernel.debug%
-    templating:
-        engines: ['php']
+        resource: "%kernel.project_dir/config/routing.yml"
+        strict_requirements: "%kernel.debug%"
     default_locale: en
     session: ~
     test: ~
@@ -19,7 +17,7 @@ oneup_flysystem:
     adapters:
         myadapter:
             local:
-                directory: %kernel.root_dir%/cache
+                directory: "kernel.project_dir%/cache"
 
     filesystems:
         myfilesystem:

--- a/Tests/Model/ContainerAwareTestCase.php
+++ b/Tests/Model/ContainerAwareTestCase.php
@@ -13,13 +13,13 @@ class ContainerAwareTestCase extends WebTestCase
     protected $client;
     protected static $container;
 
-    public function setUp():void
+    public function setUp(): void
     {
         $this->client = static::createClient();
         self::$container = $this->client->getContainer();
     }
 
-    public function tearDown():void
+    public function tearDown(): void
     {
         parent::tearDown();
 

--- a/Tests/Model/ContainerAwareTestCase.php
+++ b/Tests/Model/ContainerAwareTestCase.php
@@ -13,13 +13,13 @@ class ContainerAwareTestCase extends WebTestCase
     protected $client;
     protected static $container;
 
-    public function setUp()
+    public function setUp():void
     {
         $this->client = static::createClient();
         self::$container = $this->client->getContainer();
     }
 
-    public function tearDown()
+    public function tearDown():void
     {
         parent::tearDown();
 

--- a/Tests/StreamWrapper/StreamWrapperTest.php
+++ b/Tests/StreamWrapper/StreamWrapperTest.php
@@ -26,7 +26,7 @@ class StreamWrapperTest extends ContainerAwareTestCase
         $this->assertEquals($content, stream_get_contents($filesystem->readStream($path)));
     }
 
-    public function tearDown()
+    public function tearDown():void
     {
         $this->assertContains('myfilesystem', stream_get_wrappers());
 

--- a/Tests/StreamWrapper/StreamWrapperTest.php
+++ b/Tests/StreamWrapper/StreamWrapperTest.php
@@ -26,7 +26,7 @@ class StreamWrapperTest extends ContainerAwareTestCase
         $this->assertEquals($content, stream_get_contents($filesystem->readStream($path)));
     }
 
-    public function tearDown():void
+    public function tearDown(): void
     {
         $this->assertContains('myfilesystem', stream_get_wrappers());
 

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
 
     "require-dev": {
         "phpunit/phpunit": "^4.4",
-        "symfony/finder": "^3.3|^4.0",
-        "symfony/browser-kit": "^3.3|^4.0",
-        "symfony/asset": "^3.3|^4.0",
-        "symfony/templating": "^3.3|^4.0",
-        "symfony/translation": "^3.3|^4.0",
+        "symfony/finder": "^3.3|^4.0|^5.0",
+        "symfony/browser-kit": "^3.3|^4.0|^5.0",
+        "symfony/asset": "^3.3|^4.0|^5.0",
+        "symfony/templating": "^3.3|^4.0|^5.0",
+        "symfony/translation": "^3.3|^4.0|^5.0",
         "league/flysystem-aws-s3-v2": "^1.0",
         "league/flysystem-azure-blob-storage": "^0.1",
         "league/flysystem-cached-adapter": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,17 +22,18 @@
 
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^3.3|^4.0|^5.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "league/flysystem": "^1.0.26"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^4.4|^5.0",
-        "symfony/finder": "^3.3|^4.0|^5.0",
-        "symfony/browser-kit": "^3.3|^4.0|^5.0",
-        "symfony/asset": "^3.3|^4.0|^5.0",
-        "symfony/templating": "^3.3|^4.0|^5.0",
-        "symfony/translation": "^3.3|^4.0|^5.0",
+        "phpunit/phpunit": "^6.4",
+        "symfony/finder": "^3.4|^4.0|^5.0",
+        "symfony/browser-kit": "^3.4|^4.0|^5.0",
+        "symfony/asset": "^3.4|^4.0|^5.0",
+        "symfony/templating": "^3.4|^4.0|^5.0",
+        "symfony/translation": "^3.4|^4.0|^5.0",
+        "symfony/yaml": "^3.4|^4.0|^5.0",
         "league/flysystem-aws-s3-v2": "^1.0",
         "league/flysystem-azure-blob-storage": "^0.1",
         "league/flysystem-cached-adapter": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 
     "require": {
         "php": "^7.0",
-        "symfony/framework-bundle": "^3.3|^4.0",
+        "symfony/framework-bundle": "^3.3|^4.0|^5.0",
         "league/flysystem": "^1.0.26"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^4.4",
+        "phpunit/phpunit": "^4.4|^5.0",
         "symfony/finder": "^3.3|^4.0|^5.0",
         "symfony/browser-kit": "^3.3|^4.0|^5.0",
         "symfony/asset": "^3.3|^4.0|^5.0",


### PR DESCRIPTION
Fixes #199

Updated version of https://github.com/1up-lab/OneupFlysystemBundle/pull/200
Rebased and fixed typos, also updated to PHPUnit 6.
I had to add `--prefer-lowest` to Symfony 3 build, because some dependency is messing with the build otherwise.