### PR TITLE
Add support for AsyncAws S3

### DIFF
--- a/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
+++ b/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
@@ -32,7 +32,7 @@ class AsyncAwsS3Factory implements AdapterFactoryInterface
             ->children()
                 ->scalarNode('client')->isRequired()->end()
                 ->scalarNode('bucket')->isRequired()->end()
-                ->scalarNode('prefix')->defaultNull()->end()
+                ->scalarNode('prefix')->defaultValue('')->end()
                 ->arrayNode('options')->prototype('scalar')->end()
             ->end()
         ;

--- a/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
+++ b/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
@@ -22,7 +22,7 @@ class AsyncAwsS3Factory implements AdapterFactoryInterface
             ->replaceArgument(0, new Reference($config['client']))
             ->replaceArgument(1, $config['bucket'])
             ->replaceArgument(2, $config['prefix'])
-            ->addArgument((array) $config['options'])
+            ->addArgument($config['options'])
         ;
     }
 
@@ -32,8 +32,8 @@ class AsyncAwsS3Factory implements AdapterFactoryInterface
             ->children()
                 ->scalarNode('client')->isRequired()->end()
                 ->scalarNode('bucket')->isRequired()->end()
-                ->scalarNode('prefix')->defaultValue('')->end()
-                ->arrayNode('options')->prototype('scalar')->end()
+                ->scalarNode('prefix')->treatNullLike('')->defaultValue('')->end()
+                ->variableNode('options')->treatNullLike([])->defaultValue([])->end()
             ->end()
         ;
     }

--- a/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
+++ b/DependencyInjection/Factory/Adapter/AsyncAwsS3Factory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Reference;
+use Oneup\FlysystemBundle\DependencyInjection\Factory\AdapterFactoryInterface;
+
+class AsyncAwsS3Factory implements AdapterFactoryInterface
+{
+    public function getKey()
+    {
+        return 'async_aws_s3';
+    }
+
+    public function create(ContainerBuilder $container, $id, array $config)
+    {
+         $container
+            ->setDefinition($id, new ChildDefinition('oneup_flysystem.adapter.async_aws_s3'))
+            ->replaceArgument(0, new Reference($config['client']))
+            ->replaceArgument(1, $config['bucket'])
+            ->replaceArgument(2, $config['prefix'])
+            ->addArgument((array) $config['options'])
+        ;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('client')->isRequired()->end()
+                ->scalarNode('bucket')->isRequired()->end()
+                ->scalarNode('prefix')->defaultNull()->end()
+                ->arrayNode('options')->prototype('scalar')->end()
+            ->end()
+        ;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ OneupFlysystemBundle
 
 The OneupFlysystemBundle provides a [Flysystem](https://github.com/thephpleague/flysystem) integration for your Symfony projects. Flysystem is a filesystem abstraction which allows you to easily swap out a local filesystem for a remote one. Currently you can configure the following adapters to use in your Symfony project.
 
+* [AsyncAwsS3](https://async-aws.com/)
 * [AwsS3](http://aws.amazon.com/de/sdkforphp/)
 * [AzureBlobStorage](https://azure.microsoft.com/en-us/services/storage/blobs/)
 * [Dropbox](https://www.dropbox.com/developers)

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -21,6 +21,11 @@
                    <argument /><!-- Archive -->
                    <argument /><!-- Prefix -->
                </service>
+               <service id="oneup_flysystem.adapter.async_aws_s3" class="AsyncAws\Flysystem\S3\S3FilesystemV1" abstract="true" public="false">
+                   <argument /><!-- Client -->
+                   <argument /><!-- Bucket -->
+                   <argument /><!-- Prefix -->
+               </service>
                <service id="oneup_flysystem.adapter.awss3v2" class="League\Flysystem\AwsS3v2\AwsS3Adapter" abstract="true" public="false">
                    <argument /><!-- Client -->
                    <argument /><!-- Bucket -->

--- a/Resources/config/factories.xml
+++ b/Resources/config/factories.xml
@@ -14,6 +14,9 @@
                <service id="oneup_flysystem.adapter_factory.zip" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\ZipFactory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>
+               <service id="oneup_flysystem.adapter_factory.async_aws_s3" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AsyncAwsS3Factory">
+                   <tag name="oneup_flysystem.adapter_factory" />
+               </service>
                <service id="oneup_flysystem.adapter_factory.awss3v2" class="Oneup\FlysystemBundle\DependencyInjection\Factory\Adapter\AwsS3V2Factory">
                    <tag name="oneup_flysystem.adapter_factory" />
                </service>

--- a/Resources/doc/adapter_async_aws_s3.md
+++ b/Resources/doc/adapter_async_aws_s3.md
@@ -23,8 +23,8 @@ oneup_flysystem:
         acme.flysystem_adapter:
             async_aws_s3:
                 client: acme.s3_client
-                bucket: ~
-                prefix: ~
+                bucket: 'my_image_bucket'
+                prefix: ''
 ```
 
 ## More to know

--- a/Resources/doc/adapter_async_aws_s3.md
+++ b/Resources/doc/adapter_async_aws_s3.md
@@ -8,7 +8,7 @@ the S3 client at [async-aws.com](https://async-aws.com/clients/) or use the
 ```yml
 services:
     acme.async_s3_client:
-        class:
+        class: AsyncAws\S3\S3Client
         arguments:
             - region: 'eu-central-1'
               accessKeyId: 'AKIAIOSFODNN7EXAMPLE'

--- a/Resources/doc/adapter_asyncawss3.md
+++ b/Resources/doc/adapter_asyncawss3.md
@@ -1,0 +1,33 @@
+# Use the AsyncAwsS3 adapter
+
+In order to use the AsyncAwsS3 adapter, you first need to create a S3 client service.
+This can be done with the following configuration. Read more about instantiating
+the S3 client at [async-aws.com](https://async-aws.com/clients/) or use the
+[AsyncAws SymfonyBundle](https://async-aws.com/integration/symfony-bundle.html).
+
+```yml
+services:
+    acme.async_s3_client:
+        class:
+        arguments:
+            - region: 'eu-central-1'
+              accessKeyId: 'AKIAIOSFODNN7EXAMPLE'
+              accessKeySecret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+```
+
+Set this service as the value of the `client` key in the `oneup_flysystem` configuration.
+
+```yml
+oneup_flysystem:
+    adapters:
+        acme.flysystem_adapter:
+            async_aws_s3:
+                client: acme.s3_client
+                bucket: ~
+                prefix: ~
+```
+
+## More to know
+
+* [Create and use your filesystem](filesystem_create.md)
+* [Add a cache](filesystem_cache.md)

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -21,6 +21,7 @@ Composer will now fetch and install this bundle in the vendor directory `vendor/
 
 **Note**: There are some additional dependencies you will need to install for some of the features:
 
+* The AsyncAwsS3 adapter requires `"async-aws/flysystem-s3"`
 * The AwsS3v3 adapter requires `"league/flysystem-aws-s3-v3"`
 * The AwsS3v2 adapter requires `"league/flysystem-aws-s3-v2"`
 * The Azure Blob Storage adapter requires `"league/flysystem-azure-blob-storage"`
@@ -77,6 +78,7 @@ oneup_flysystem:
 
 There are a bunch of adapters for you to use:
 
+* [AsyncAwsS3](adapter_asyncawss3.md)
 * [AwsS3](adapter_awss3.md)
 * [AzureBlobStorage](adapter_azureblob.md)
 * [Copy.com](https://github.com/copy-app/php-client-library)

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -78,7 +78,7 @@ oneup_flysystem:
 
 There are a bunch of adapters for you to use:
 
-* [AsyncAwsS3](adapter_asyncawss3.md)
+* [AsyncAwsS3](adapter_async_aws_s3.md)
 * [AwsS3](adapter_awss3.md)
 * [AzureBlobStorage](adapter_azureblob.md)
 * [Copy.com](https://github.com/copy-app/php-client-library)

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "litipk/flysystem-fallback-adapter": "^0.1",
         "jenko/flysystem-gaufrette": "^1.0",
         "superbalist/flysystem-google-storage": "^4.0",
-        "league/flysystem-replicate-adapter": "^1.0"
+        "league/flysystem-replicate-adapter": "^1.0",
+        "async-aws/flysystem-s3": "^0.4.0"
     },
 
     "suggest": {


### PR DESCRIPTION
I see that my last contribution was 5 years ago and I added docs for AwsS3v3. https://github.com/1up-lab/OneupFlysystemBundle/pull/72

This time I'll add support for AsyncAws S3. 

Here are some links and resources: 
- https://async-aws.com/
- https://github.com/async-aws/flysystem-s3
- https://github.com/async-aws/s3


This will fix #208