### PR TITLE
Update docs with a how-to for php file config

### DIFF
--- a/Resources/doc/filesystem_php_config.md
+++ b/Resources/doc/filesystem_php_config.md
@@ -1,0 +1,30 @@
+# Config based on PHP files
+
+If you're using Symfony 5 and want to configure this bundle with a PHP file instead of a YAML,
+you can set up the `config/packages/oneup_flysystem.php` file like this:
+
+```php
+
+<?php declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void
+{
+    $configurator->extension('oneup_flysystem', [
+        'adapters' => [
+            'my_adapter' => [
+                'local' => [
+                    'directory' => '%kernel.root_dir%/cache'
+                ]
+            ]
+        ],
+        'filesystems' => [
+            'my_filesystem' => [
+                'adapter' => 'my_adapter',
+                'visibility' => 'private'
+            ]
+        ]
+    ]);
+};
+```

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -108,3 +108,4 @@ After installing and setting up the basic functionality of this bundle you can m
 * [Running the tests](tests.md)
 * [Use your own flysystem adapters](adapter_custom.md)
 * [Configure stream wrapper for your filesystems](filesystem_stream_wrapper.md)
+* [Config based on PHP files](filesystem_php_config.md)


### PR DESCRIPTION
Symfony 6 will recommend the use of PHP files instead of YAML for config, so it's convenient to show users how to perform PHP config from now on.