### PR TITLE
Document s3 adapter options usage

### DIFF
--- a/Resources/doc/adapter_awss3.md
+++ b/Resources/doc/adapter_awss3.md
@@ -86,6 +86,28 @@ oneup_flysystem:
 
 For more details on the other parameters, take a look at the [Flysystem documentation](http://flysystem.thephpleague.com/adapter/aws-s3-v2/).
 
+## Additional parameters
+Use `options` config to pass additional parameters to AWS.
+
+### Example use case
+
+Sending files to S3 bucket owned by another AWS account.
+In this situation default `ACL` value, which is `private`, prevents bucket owner from viewing the file.
+
+To allow bucket owner full control over an object use below config example:
+
+```yml
+oneup_flysystem:
+    adapters:
+        acme.flysystem_adapter:
+            awss3v3:
+                client: acme.s3_client
+                bucket: foo
+                prefix: ~
+                options:
+                    ACL: bucket-owner-full-control
+```
+
 ## More to know
 * [Create and use your filesystem](filesystem_create.md)
 * [Add a cache](filesystem_cache.md)


### PR DESCRIPTION
Adds info about using `options` config for AWS S3 adapter.
Example use case of changing `ACL` value to `bucket-owner-full-control` provided.

I had to dig into codebase in order to figure out how to change object acl. 
Thought it could be helpful for somebody else as well.