### PR TITLE
Support for async-aws/flysystem-s3 1.0

### DIFF
--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -21,7 +21,7 @@
                    <argument /><!-- Archive -->
                    <argument /><!-- Prefix -->
                </service>
-               <service id="oneup_flysystem.adapter.async_aws_s3" class="AsyncAws\Flysystem\S3\S3FilesystemV1" abstract="true" public="false">
+               <service id="oneup_flysystem.adapter.async_aws_s3" class="AsyncAws\Flysystem\S3\AsyncAwsS3Adapter" abstract="true" public="false">
                    <argument /><!-- Client -->
                    <argument /><!-- Bucket -->
                    <argument /><!-- Prefix -->

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "async-aws/flysystem-s3": "^0.4.0",
+        "async-aws/flysystem-s3": "^1.0",
         "jenko/flysystem-gaufrette": "^1.0",
         "league/flysystem-aws-s3-v2": "^1.0",
         "league/flysystem-azure-blob-storage": "^0.1",
@@ -74,6 +74,9 @@
         "spatie/flysystem-dropbox": "Use Dropbox storage",
         "superbalist/flysystem-google-storage": "Allows you to use Google Cloud Storage buckets",
         "twistor/flysystem-stream-wrapper": "Allows you to use stream wrapper"
+    },
+    "conflict": {
+        "async-aws/flysystem-s3": "<1.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
When bumping to 1.0, the Async AWS folks decided to rename their adapter class. This PR makes the necessary adjustments.

I don't know how the BC policies of this project are. Should I build some kind of compatibility layer to support both, 0.4 and 1.0 of that library at the same time? Or is this change acceptable as it is?