### PR TITLE
Use same name for memory adapter

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -7,7 +7,7 @@ In order to run the UnitTests of this bundle, clone it first
 
 After the cloning process, install all vendors by running the corresponding composer command.
 
-    $> composer update --dev
+    $> composer install --dev
 
 ## Run PHPUnit
 You can run the unit tests by simply performing the follwowing command:

--- a/src/Resources/config/adapters.xml
+++ b/src/Resources/config/adapters.xml
@@ -32,7 +32,7 @@
             <argument/><!-- VisibilityConverter -->
             <argument/><!-- MimeTypeDetector -->
         </service>
-        <service id="oneup_flysystem.adapter.in_memory" class="League\Flysystem\InMemory\InMemoryFilesystemAdapter" abstract="true" public="false">
+        <service id="oneup_flysystem.adapter.memory" class="League\Flysystem\InMemory\InMemoryFilesystemAdapter" abstract="true" public="false">
             <argument/><!-- defaultVisibility -->
         </service>
         <service id="oneup_flysystem.adapter.async_aws_s3" class="AsyncAws\Flysystem\S3\S3FilesystemV2" abstract="true" public="false">

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -11,18 +11,42 @@ framework:
 
 oneup_flysystem:
     adapters:
-        myadapter:
+        local:
             local:
                 location: "%kernel.project_dir%/cache"
+        memory:
+            memory: ~
+
+        async_aws_s3:
+            async_aws_s3:
+                client: 'test'
+                bucket: 'test'
+
+        custom:
+            custom:
+                service: 'test'
+
+        ftp:
+            ftp:
+                connectionOptions: 'test'
+
+        gitlab:
+            gitlab:
+                client: 'test'
+
+        sftp:
+            sftp:
+                connectionProvider: 'test'
+                root: 'test'
 
     filesystems:
         myfilesystem:
-            adapter: myadapter
+            adapter: local
 
         myfilesystem2:
-            adapter: myadapter
+            adapter: local
             visibility: public
 
         myfilesystem3:
-            adapter: myadapter
+            adapter: local
             visibility: private


### PR DESCRIPTION
Hi, I got an error with the 4.0 version: `1) Vich\UploaderBundle\Tests\VichUploaderBundleTest::testFlysystemOneUpKernel
Symfony\Component\DependencyInjection\Exception\RuntimeException: Service "oneup_flysystem.memory_adapter_adapter": Parent definition "oneup_flysystem.adapter.memory" does not exist.
`

I solved using the old name "memory", the name was "in_memory" in configuration and "memory" in yaml. I thought that it could be better to use the same name as before.

Moreover, I added adapter creations to tests, it becomes red in master, green in my branch!