### PR TITLE
Use the correct AsyncAWS adapter for Flysystem 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,8 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "async-aws/flysystem-s3": "^0.4.0",
         "friendsofphp/php-cs-fixer": "^2.16",
+        "league/flysystem-async-aws-s3": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "league/flysystem-ftp": "^2.0",
         "league/flysystem-memory": "^2.0",

--- a/doc/index.md
+++ b/doc/index.md
@@ -25,7 +25,7 @@ Composer will now fetch and install this bundle in the vendor directory `vendor/
 * The FTP adapter requires `"league/flysystem-ftp"`
 * The SFTP adapter requires `"league/flysystem-sftp"`
 * The InMemory adapter requires `"league/flysystem-memory"`
-* The AsyncAwsS3 adapter requires `"async-aws/flysystem-s3"`
+* The AsyncAwsS3 adapter requires `"league/flysystem-async-aws-s3"`
 * The Gitlab adapter requires `"royvoetman/flysystem-gitlab-storage"`
 
 ### Step 2: Enable the bundle

--- a/src/Resources/config/adapters.xml
+++ b/src/Resources/config/adapters.xml
@@ -35,7 +35,7 @@
         <service id="oneup_flysystem.adapter.memory" class="League\Flysystem\InMemory\InMemoryFilesystemAdapter" abstract="true" public="false">
             <argument/><!-- defaultVisibility -->
         </service>
-        <service id="oneup_flysystem.adapter.async_aws_s3" class="AsyncAws\Flysystem\S3\S3FilesystemV2" abstract="true" public="false">
+        <service id="oneup_flysystem.adapter.async_aws_s3" class="League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter" abstract="true" public="false">
             <argument/><!-- Client -->
             <argument/><!-- Bucket -->
             <argument/><!-- Prefix -->


### PR DESCRIPTION
The `async-aws/flysystem-s3` adapter recommended by this package is not compatible with Flysystem 2. This PR should fix that.