### PR TITLE
Use valid default for AWS S3 prefix

### DIFF
--- a/src/DependencyInjection/Factory/Adapter/AwsS3V3Factory.php
+++ b/src/DependencyInjection/Factory/Adapter/AwsS3V3Factory.php
@@ -37,7 +37,7 @@ class AwsS3V3Factory implements AdapterFactoryInterface
             ->children()
                 ->scalarNode('client')->isRequired()->end()
                 ->scalarNode('bucket')->isRequired()->end()
-                ->scalarNode('prefix')->defaultNull()->end()
+                ->scalarNode('prefix')->defaultValue('')->end()
                 ->scalarNode('visibilityConverter')->defaultNull()->end()
                 ->scalarNode('mimeTypeDetector')->defaultNull()->end()
                 ->arrayNode('options')


### PR DESCRIPTION
The constructor for `League\Flysystem\AwsS3V3\AwsS3V3Adapter` has a non-nullable `$prefix` parameter which defaults to an empty string.  The configuration tree for the S3 adapter isn't compatible with that signature by using a null value by default, so this PR updates the config to match the class' requirements.