### PR TITLE
Fix filesystem alias type

### DIFF
--- a/src/DependencyInjection/OneupFlysystemExtension.php
+++ b/src/DependencyInjection/OneupFlysystemExtension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Oneup\FlysystemBundle\DependencyInjection;
 
-use League\Flysystem\FilesystemAdapter;
+use League\Flysystem\FilesystemOperator;
 use Oneup\FlysystemBundle\DependencyInjection\Factory\FactoryInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -114,7 +114,7 @@ class OneupFlysystemExtension extends Extension
                 $aliasName .= 'Filesystem';
             }
 
-            $container->registerAliasForArgument($id, FilesystemAdapter::class, $aliasName)->setPublic(false);
+            $container->registerAliasForArgument($id, FilesystemOperator::class, $aliasName)->setPublic(false);
         }
 
         return new Reference($id);

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -50,3 +50,11 @@ oneup_flysystem:
         myfilesystem3:
             adapter: local
             visibility: private
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Oneup\FlysystemBundle\Tests\DependencyInjection\TestService:
+        public: true

--- a/tests/DependencyInjection/OneupFlysystemExtensionTest.php
+++ b/tests/DependencyInjection/OneupFlysystemExtensionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Oneup\FlysystemBundle\Tests\DependencyInjection;
 
 use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemOperator;
 use League\Flysystem\Visibility;
 use Oneup\FlysystemBundle\DependencyInjection\OneupFlysystemExtension;
 use Oneup\FlysystemBundle\Tests\Model\ContainerAwareTestCase;
@@ -95,10 +96,13 @@ class OneupFlysystemExtensionTest extends ContainerAwareTestCase
             ],
         ]);
 
-        $aliasName = 'League\Flysystem\FilesystemAdapter $acmeFilesystem';
+        $aliasName = 'League\Flysystem\FilesystemOperator $acmeFilesystem';
 
         self::assertTrue($container->hasAlias($aliasName));
         self::assertSame('oneup_flysystem.acme_filesystem_filesystem', (string) $container->getAlias($aliasName));
+
+        self::assertTrue($container->hasAlias(Filesystem::class));
+        self::assertSame('oneup_flysystem.acme_filesystem_filesystem', (string) $container->getAlias(Filesystem::class));
     }
 
     public function testServiceAliasWithoutFilesystemSuffix(): void
@@ -121,10 +125,22 @@ class OneupFlysystemExtensionTest extends ContainerAwareTestCase
             ],
         ]);
 
-        $aliasName = 'League\Flysystem\FilesystemAdapter $acmeFilesystem';
+        $aliasName = 'League\Flysystem\FilesystemOperator $acmeFilesystem';
 
         self::assertTrue($container->hasAlias($aliasName));
         self::assertSame('oneup_flysystem.acme_filesystem', (string) $container->getAlias($aliasName));
+
+        self::assertTrue($container->hasAlias(Filesystem::class));
+        self::assertSame('oneup_flysystem.acme_filesystem', (string) $container->getAlias(Filesystem::class));
+    }
+
+    public function testServiceAliasInjection(): void
+    {
+        /** @var TestService $testService */
+        $testService = self::$container->get(TestService::class);
+
+        self::assertInstanceOf(TestService::class, $testService);
+        self::assertInstanceOf(Filesystem::class, $testService->filesystem);
     }
 
     private function loadExtension(array $config): ContainerBuilder
@@ -133,5 +149,18 @@ class OneupFlysystemExtensionTest extends ContainerAwareTestCase
         $extension->load($config, $container = new ContainerBuilder());
 
         return $container;
+    }
+}
+
+/**
+ * @internal
+ */
+final class TestService
+{
+    public FilesystemOperator $filesystem;
+
+    public function __construct(FilesystemOperator $myfilesystem)
+    {
+        $this->filesystem = $myfilesystem;
     }
 }


### PR DESCRIPTION
It registered filesystem binding as `FilesystemAdapter` instead of `FilesystemOperator` causing auto-wiring to crash with named parameters.