### PR TITLE
Remove unnecessary back-compat code

### DIFF
--- a/src/DependencyInjection/OneupFlysystemExtension.php
+++ b/src/DependencyInjection/OneupFlysystemExtension.php
@@ -107,15 +107,13 @@ class OneupFlysystemExtension extends Extension
             $alias->setPublic(true);
         }
 
-        if (method_exists($container, 'registerAliasForArgument')) {
-            $aliasName = $name;
+        $aliasName = $name;
 
-            if (!preg_match('~filesystem$~i', $aliasName)) {
-                $aliasName .= 'Filesystem';
-            }
-
-            $container->registerAliasForArgument($id, FilesystemOperator::class, $aliasName)->setPublic(false);
+        if (!preg_match('~filesystem$~i', $aliasName)) {
+            $aliasName .= 'Filesystem';
         }
+
+        $container->registerAliasForArgument($id, FilesystemOperator::class, $aliasName)->setPublic(false);
 
         return new Reference($id);
     }


### PR DESCRIPTION
`ContainerBuilder::registerAliasForArgument()` was added in Symfony 4.2.  Since 4.4 is the minimum, the back-compat check isn't needed anymore.