### PR TITLE
fix: use the "mount" attribute as the mount identifier

### DIFF
--- a/src/DependencyInjection/Compiler/FilesystemPass.php
+++ b/src/DependencyInjection/Compiler/FilesystemPass.php
@@ -21,7 +21,7 @@ class FilesystemPass implements CompilerPassInterface
         $filesystems = [];
 
         foreach ($configuredFilesystems as $id => $attributes) {
-            $filesystems[$id] = new Reference($id);
+            $filesystems[$attributes[0]['mount'] ?? $attributes[0]['key'] ?? $id] = new Reference($id);
         }
 
         $mountManager->replaceArgument(0, $filesystems);

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -22,6 +22,7 @@ oneup_flysystem:
         myfilesystem2:
             adapter: myadapter
             visibility: public
+            mount: 'local'
 
         myfilesystem3:
             adapter: myadapter

--- a/tests/DependencyInjection/Compiler/FilesystemPassTest.php
+++ b/tests/DependencyInjection/Compiler/FilesystemPassTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneup\FlysystemBundle\Tests\DependencyInjection\Compiler;
+
+use League\Flysystem\Filesystem;
+use League\Flysystem\MountManager;
+use Oneup\FlysystemBundle\Tests\Model\ContainerAwareTestCase;
+
+final class FilesystemPassTest extends ContainerAwareTestCase
+{
+    public function testMountIdentifiers(): void
+    {
+        /** @var MountManager $mountManager */
+        $mountManager = self::$container->get('oneup_flysystem.mount_manager');
+        /** @var Filesystem $filesystem1 */
+        $filesystem1 = self::$container->get('oneup_flysystem.myfilesystem_filesystem');
+        /** @var Filesystem $filesystem2 */
+        $filesystem2 = self::$container->get('oneup_flysystem.myfilesystem2_filesystem');
+
+        self::assertFalse($filesystem1->fileExists('foo'));
+        self::assertFalse($filesystem2->fileExists('bar'));
+
+        $mountManager->write('myfilesystem://foo', 'foo');
+        $mountManager->write('local://bar', 'bar');
+
+        self::assertTrue($filesystem1->fileExists('foo'));
+        self::assertTrue($filesystem2->fileExists('bar'));
+
+        $mountManager->delete('myfilesystem://foo');
+        $mountManager->delete('local://bar');
+
+        self::assertFalse($filesystem1->fileExists('foo'));
+        self::assertFalse($filesystem2->fileExists('bar'));
+    }
+}


### PR DESCRIPTION
Given the following configuration:
```yaml
oneup_flysystem:
    # ...
    filesystems:
        foo_fs:
            # ...
            mount: foo
```
The current behaviour uses the filesystem service identifier as mount identifier:
```php
$container->get('oneup_flysystem.mount_manager')->write('oneup_flysystem.foo_fs_filesystem://bar/baz', 'qux');
```
But when I use the `mount` attribute I expect it to be my mount identifier:
```php
$container->get('oneup_flysystem.mount_manager')->write('foo://bar/baz', 'qux');
```
And if the `mount` attribute is not specified, let's default to the filename key:
```php
$container->get('oneup_flysystem.mount_manager')->write('foo_fs://bar/baz', 'qux');
```



