### PR TITLE
Fix links in documentation for SFTP adapter

### DIFF
--- a/doc/adapter_sftp.md
+++ b/doc/adapter_sftp.md
@@ -14,8 +14,7 @@ oneup_flysystem:
                     root: '/upload'
 ```
 
-For more details on the other parameters, take a look at the [Flysystem documentation](https://flysystem.thephpleague.com/v2/docs/adapter/aws-s3-v3/).
+For more details on the other parameters, take a look at the [Flysystem documentation](https://flysystem.thephpleague.com/v2/docs/adapter/sftp/).
 
 ## More to know
 * [Create and use your filesystem](filesystem_create.md)
-* [Add a cache](filesystem_cache.md)


### PR DESCRIPTION
While browsing through the documentation I noticed some small issues in the page about the SFTP adapter. The link to the Flysystem documentation points to the wrong page, while “Add a cache” leads to nowhere.

I fixed the first link and removed the second latter, because the page it’s referring to doesn’t seem to exist (anymore).

(By the way, thanks for creating and maintaining this library!)