### PR TITLE
Fixed lines after lint:yaml failed

### DIFF
--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -27,11 +27,11 @@ oneup_flysystem:
                 location: '%kernel.project_dir%/cache'
                 permissions:
                     files:
-                        public: 0644
-                        private: 0600
+                        public: '0644'
+                        private: '0600'
                     directories:
-                        public: 0755
-                        private: 0700
+                        public: '0755'
+                        private: '0700'
 
         memory:
             memory: ~


### PR DESCRIPTION
I was using this bundle in my project, and as I was trying to make some test, the command yaml:lint returned with an error. 
I fixed it by adding quotes and there's no errors now !