### PR TITLE
Resolve ConnectivityChecker as service when configured

### DIFF
--- a/src/DependencyInjection/Factory/Adapter/SftpFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/SftpFactory.php
@@ -10,6 +10,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class SftpFactory implements AdapterFactoryInterface
 {
@@ -22,6 +23,10 @@ class SftpFactory implements AdapterFactoryInterface
     {
         $root = $config['options']['root'];
         unset($config['options']['root']);
+
+        if (null !== $config['options']['connectivityChecker']) {
+            $config['options']['connectivityChecker'] = new Reference($config['options']['connectivityChecker']);
+        }
 
         $container
             ->setDefinition($id, new ChildDefinition('oneup_flysystem.adapter.sftp'))


### PR DESCRIPTION
When I want to use newly fixed `connectivityChecker` field. I discovered I cannot use it, because symfony DI passes only string there.

So here is fix.

Example of configuration YAML:

```
    some_sftp_adapter:
      sftp:
        options:
          host: "%sftp_host%"
          username: "%sftp_username%"
          password: "%sftp_password%"
          root: "%sftp_root%"
          timeout: 1800 # 30 minutes
          connectivityChecker: App\Service\Sftp\SftpPingConnectivityChecker
```