### PR TITLE
update local adapter configuration to work with League\Flysystem

### DIFF
--- a/doc/adapter_local.md
+++ b/doc/adapter_local.md
@@ -14,10 +14,10 @@ oneup_flysystem:
                 writeFlags: ~
                 linkHandling: ~
                 permissions:
-                    files:
+                    file:
                         public: 0644
                         private: 0600
-                    directories:
+                    dir:
                         public: 0755
                         private: 0700
 ```

--- a/src/DependencyInjection/Factory/Adapter/LocalFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/LocalFactory.php
@@ -69,4 +69,3 @@ class LocalFactory implements AdapterFactoryInterface
         ;
     }
 }
-

--- a/src/DependencyInjection/Factory/Adapter/LocalFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/LocalFactory.php
@@ -23,7 +23,7 @@ class LocalFactory implements AdapterFactoryInterface
     {
         $visibilityConverter = null;
 
-        if (isset($config['visibilityConverter']) && null !== $config['visibilityConverter']) {
+        if (isset($config['permissions']) && null !== $config['permissions']) {
             $visibilityConverter = new Definition(PortableVisibilityConverter::class);
             $visibilityConverter->setFactory([PortableVisibilityConverter::class, 'fromArray']);
             $visibilityConverter->setArgument(0, $config['permissions'] ?? []);
@@ -48,13 +48,13 @@ class LocalFactory implements AdapterFactoryInterface
                 ->scalarNode('location')->isRequired()->end()
                 ->arrayNode('permissions')
                     ->children()
-                        ->arrayNode('files')
+                        ->arrayNode('file')
                             ->children()
                                 ->scalarNode('public')->defaultNull()->end()
                                 ->scalarNode('private')->defaultNull()->end()
                             ->end()
                         ->end()
-                        ->arrayNode('directories')
+                        ->arrayNode('dir')
                             ->children()
                                 ->scalarNode('public')->defaultNull()->end()
                                 ->scalarNode('private')->defaultNull()->end()
@@ -69,3 +69,4 @@ class LocalFactory implements AdapterFactoryInterface
         ;
     }
 }
+

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -26,10 +26,10 @@ oneup_flysystem:
             local:
                 location: '%kernel.project_dir%/cache'
                 permissions:
-                    files:
+                    file:
                         public: '0644'
                         private: '0600'
-                    directories:
+                    dir:
                         public: '0755'
                         private: '0700'
 

--- a/tests/App/config/config.yml
+++ b/tests/App/config/config.yml
@@ -27,11 +27,11 @@ oneup_flysystem:
                 location: '%kernel.project_dir%/cache'
                 permissions:
                     file:
-                        public: '0644'
-                        private: '0600'
+                        public: 0644
+                        private: 0600
                     dir:
-                        public: '0755'
-                        private: '0700'
+                        public: 0755
+                        private: 0700
 
         memory:
             memory: ~


### PR DESCRIPTION
### Bug Report

|    Q        |   A
|------------ | ------
| BC Break    | yes
| Version     | 4.1.4

#### Summary

Permission config parameters for local adapter are never used.

Code checks existence of visibilityConverter in configuration which is not allowed. Additionally used parameters for function fromArray are not valid.