### PR TITLE
supports env variables in configuration

### DIFF
--- a/src/DependencyInjection/OneupFlysystemExtension.php
+++ b/src/DependencyInjection/OneupFlysystemExtension.php
@@ -28,6 +28,7 @@ class OneupFlysystemExtension extends Extension
 
         $configuration = new Configuration($adapterFactories);
         $config = $this->processConfiguration($configuration, $configs);
+        $config = $container->resolveEnvPlaceholders($config, true);
 
         $loader->load('adapters.xml');
         $loader->load('flysystem.xml');


### PR DESCRIPTION
Usage:

oneup_flysystem.yaml
```
oneup_flysystem:
    adapters:
        local:
            local:
                location: '%app.uploads.dir%'
                permissions:
                    file:
                        public: 0o644
                        private: 0o600
                    dir:
                        public: 0o755
                        private: 0o700
        ovh:
            awss3v3:
                client: app.ovh_s3_client
                bucket: '%app.ovh_s3_client.bucket%'
                prefix: '%app.ovh_s3_client.prefix%'

    filesystems:
        uploads:
            adapter: '%app.filesystem_uploads.adapter%'
            visibility: private
            directory_visibility: private
```

services.yaml
```
    app.filesystem_uploads.adapter: '%env(FILESYSTEM_UPLOAD_ADAPTER)%'
```


Without the fix: 

  Incompatible use of dynamic environment variables "FILESYSTEM_UPLOAD_ADAPTER" found in parameters.  