### PR TITLE
Be able to configure $lazyRootCreation of LocalFilesystemAdapter

### DIFF
--- a/doc/adapter_local.md
+++ b/doc/adapter_local.md
@@ -20,6 +20,7 @@ oneup_flysystem:
                     dir:
                         public: 0o755
                         private: 0o700
+                lazyRootCreation: ~ # boolean (default "false")
 ```
 
 For more details on the `lazy` parameter, take a look at the [Symfony documentation](http://symfony.com/doc/current/components/dependency_injection/lazy_services.html).

--- a/src/DependencyInjection/Factory/Adapter/LocalFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/LocalFactory.php
@@ -37,6 +37,7 @@ class LocalFactory implements AdapterFactoryInterface
             ->replaceArgument(2, $config['writeFlags'])
             ->replaceArgument(3, $config['linkHandling'])
             ->replaceArgument(4, $config['mimeTypeDetector'])
+            ->replaceArgument(5, $config['lazyRootCreation'])
         ;
     }
 
@@ -91,6 +92,7 @@ class LocalFactory implements AdapterFactoryInterface
                 ->scalarNode('writeFlags')->defaultValue(\LOCK_EX)->end()
                 ->scalarNode('linkHandling')->defaultValue(LocalFilesystemAdapter::DISALLOW_LINKS)->end()
                 ->scalarNode('mimeTypeDetector')->defaultNull()->end()
+                ->scalarNode('lazyRootCreation')->defaultValue(false)->end()
             ->end()
         ;
     }

--- a/src/Resources/config/adapters.xml
+++ b/src/Resources/config/adapters.xml
@@ -9,6 +9,7 @@
             <argument/><!-- writeFlags -->
             <argument/><!-- linkHandling -->
             <argument/><!-- MimeTypeDetector -->
+            <argument/><!-- lazyRootCreation -->
         </service>
         <service id="oneup_flysystem.adapter.awss3v3" class="League\Flysystem\AwsS3V3\AwsS3V3Adapter" abstract="true" public="false">
             <argument/><!-- S3ClientInterface -->


### PR DESCRIPTION
Hello there!

There is a PR to add the support of the `$lazyRootCreation` parameter for the `LocalFilesystemAdapter`.
I updated Factory, Adapter service abstraction and docs.
I didn't any relevant test to update or add.
Let me know if I need to rework something! 😃  