### PR TITLE
Add support for useRawListOptions in FtpConnection

### DIFF
--- a/src/DependencyInjection/Factory/Adapter/FtpFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/FtpFactory.php
@@ -55,6 +55,7 @@ class FtpFactory implements AdapterFactoryInterface
                         ->booleanNode('ignorePassiveAddress')->defaultNull()->end()
                         ->booleanNode('timestampsOnUnixListingsEnabled')->defaultFalse()->end()
                         ->booleanNode('recurseManually')->defaultFalse()->end()
+                        ->booleanNode('useRawListOptions')->defaultFalse()->end()
                     ->end()
                 ->end()
                 ->scalarNode('connectionProvider')->defaultNull()->end()


### PR DESCRIPTION
The FtpConnection class from the Flysystem library offers a feature named useRawListOptions. However, I've noticed this bundle does not currently support this.

https://github.com/thephpleague/flysystem/blob/3.x/src/Ftp/FtpConnectionOptions.php#L122