### PR TITLE
chore: add ci-tests for php 8.3,

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@2.7.0
+              uses: shivammathur/setup-php@2.30.0
               with:
                   php-version: 8.0
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
                   coverage: none
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install the dependencies
               run: composer install --no-interaction --no-suggest
@@ -36,7 +36,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.0, 8.1, 8.2]
+                php: [8.0, 8.1, 8.2, 8.3]
                 symfony: [4.4, 5.4, 6.0, 7.0]
                 exclude:
                   - symfony: 7.0
@@ -45,14 +45,14 @@ jobs:
                     php: 8.1
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@2.7.0
+              uses: shivammathur/setup-php@2.30.0
               with:
                   php-version: ${{ matrix.php }}
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
                   coverage: none
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install the dependencies
               run: |
@@ -66,14 +66,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Setup PHP
-              uses: shivammathur/setup-php@2.7.0
+              uses: shivammathur/setup-php@2.30.0
               with:
                   php-version: 8.0
                   extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
                   coverage: none
 
             - name: Checkout
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install the dependencies
               run: composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest


### PR DESCRIPTION
fix ci deprecations