### PR TITLE
Fix spelling of "defaultVisiblity" => "defaultVisibility"

### DIFF
--- a/src/DependencyInjection/Factory/Adapter/GoogleCloudStorageFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/GoogleCloudStorageFactory.php
@@ -32,7 +32,7 @@ class GoogleCloudStorageFactory implements AdapterFactoryInterface
             ->replaceArgument(0, $bucket)
             ->replaceArgument(1, $config['prefix'])
             ->replaceArgument(2, $visibilityHandler)
-            ->replaceArgument(3, $config['defaultVisiblity'])
+            ->replaceArgument(3, $config['defaultVisibility'])
             ->replaceArgument(4, $config['mimeTypeDetector'])
         ;
     }
@@ -45,7 +45,7 @@ class GoogleCloudStorageFactory implements AdapterFactoryInterface
             ->scalarNode('bucket')->isRequired()->end()
             ->scalarNode('prefix')->treatNullLike('')->defaultValue('')->end()
             ->scalarNode('visibilityHandler')->defaultNull()->end()
-            ->scalarNode('defaultVisiblity')->defaultValue(Visibility::PRIVATE)->end()
+            ->scalarNode('defaultVisibility')->defaultValue(Visibility::PRIVATE)->end()
             ->scalarNode('mimeTypeDetector')->defaultNull()->end()
             ->end()
         ;

--- a/src/DependencyInjection/Factory/Adapter/InMemoryFactory.php
+++ b/src/DependencyInjection/Factory/Adapter/InMemoryFactory.php
@@ -21,7 +21,7 @@ class InMemoryFactory implements AdapterFactoryInterface
     {
         $container
             ->setDefinition($id, new ChildDefinition('oneup_flysystem.adapter.memory'))
-            ->replaceArgument(0, $config['defaultVisiblity'])
+            ->replaceArgument(0, $config['defaultVisibility'])
         ;
     }
 
@@ -29,7 +29,7 @@ class InMemoryFactory implements AdapterFactoryInterface
     {
         $node
             ->children()
-                ->scalarNode('defaultVisiblity')->defaultValue(Visibility::PUBLIC)->end()
+                ->scalarNode('defaultVisibility')->defaultValue(Visibility::PUBLIC)->end()
             ->end()
         ;
     }


### PR DESCRIPTION
https://github.com/1up-lab/OneupFlysystemBundle/issues/255

I just come across this, as my IDE did notice.

Needs a closer look.