### PR TITLE
Remove symfony/templating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "symfony/finder": "^5.4 || ^6.0 || ^7.0",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^7.0",
-        "symfony/templating": "^5.4 || ^6.0 || ^7.0",
         "symfony/translation": "^5.4 || ^6.0 || ^7.0",
         "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
     },


### PR DESCRIPTION
The `symfony/templating` library is deprecated as of Symfony 6.4 and will be removed in Symfony 7. OneupFlysystemBundle requires `symfony/templating`, but does not use it anywhere as far as I can tell. There are no results outside of composer.json if I search the repository for "templ", and all tests pass with the package uninstalled.