### PR TITLE
Fix deprecation for Symfony\Component\HttpKernel\DependencyInjection\Extension

### DIFF
--- a/src/DependencyInjection/OneupFlysystemExtension.php
+++ b/src/DependencyInjection/OneupFlysystemExtension.php
@@ -11,9 +11,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class OneupFlysystemExtension extends Extension
 {


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Oneup\FlysystemBundle\DependencyInjection\OneupFlysystemExtension".